### PR TITLE
adding conditions to identity outputs

### DIFF
--- a/ArmTemplates/function-app.json
+++ b/ArmTemplates/function-app.json
@@ -137,11 +137,12 @@
             "value": "[split(reference(parameters('functionAppName')).possibleOutboundIpAddresses, ',')]"
         },
         "ManagedServiceIdentityId": {
+            "condition": "[equals(parameters('systemAssignedIdentity'), 'SystemAssigned')]",
             "type": "string",
             "value": "[reference(parameters('functionAppName'), '2018-11-01', 'Full').identity.principalId]"
         },
         "StagingManagedServiceIdentityId": {
-            "condition": "[parameters('deployStagingSlot')]",
+            "condition": "[and(parameters('deployStagingSlot'),equals(parameters('systemAssignedIdentity'), 'SystemAssigned'))]",
             "type": "string",
             "value": "[reference('staging', '2018-11-01', 'Full').identity.principalId]"
         }


### PR DESCRIPTION
it appears that the existing function-apps.json has a bug which means it tries to always output the identity even though a system assigned identity isn't used.  This fails.

This change adds conditions to the outputs so they only run when system assigned identity is requested.