### PR TITLE
Optional - Add dynamic ability to deploy SQL server without auditingSettings or securityAlertPolicies

### DIFF
--- a/ArmTemplates/sql-server.json
+++ b/ArmTemplates/sql-server.json
@@ -48,6 +48,7 @@
     },
     "sqlStorageAccountName": {
       "type": "string",
+      "defaultValue": "",
       "metadata": {
         "description": "Name of the SQL logs storage account for the environment"
       }
@@ -125,6 +126,7 @@
           ]
         },
         {
+          "condition": "[greater(length(parameters('sqlStorageAccountName')), 0)]",
           "apiVersion": "2017-03-01-preview",
           "type": "auditingSettings",
           "name": "[variables('AuditPolicyName')]",
@@ -134,7 +136,7 @@
           "properties": {
             "state": "Enabled",
             "storageEndpoint": "[concat('https://', parameters('sqlStorageAccountName'), '.blob.core.windows.net/')]",
-            "storageAccountAccessKey": "[listKeys(resourceId('Microsoft.Storage/storageAccounts', parameters('sqlStorageAccountName')), providers('Microsoft.Storage', 'storageAccounts').apiVersions[0]).keys[0].value]",
+            "storageAccountAccessKey": "[if(not(equals(parameters('sqlStorageAccountName'), '')), listKeys(resourceId('Microsoft.Storage/storageAccounts', parameters('sqlStorageAccountName')), providers('Microsoft.Storage', 'storageAccounts').apiVersions[0]).keys[0].value, null())]",
             "retentionDays": 90,
             "auditActionsAndGroups": [
               "BATCH_COMPLETED_GROUP",
@@ -145,6 +147,7 @@
           }
         },
         {
+          "condition": "[greater(length(parameters('sqlStorageAccountName')), 0)]",
           "apiVersion": "2017-03-01-preview",
           "type": "securityAlertPolicies",
           "name": "[variables('SecurityAlertPolicyName')]",


### PR DESCRIPTION
This PR adds a conditions to check whether a storage account has been set, if it has then it will deploy auditingSettings and securityAlertPolicies, if it isn't then the SQL server is deployed without  auditingSettings or securityAlertPolicies.

It is recommended that we always have auditing settings enabled by default. If you don't, Defender for Cloud flags up a low severity recommendation, so we may not want to merge this work, to ensure that an SQL server can't be deployed without them.