### PR TITLE
Reworked sql firewalls rules deployment

### DIFF
--- a/ArmTemplates/sql-server-firewall-rules.json
+++ b/ArmTemplates/sql-server-firewall-rules.json
@@ -9,20 +9,6 @@
         "description": "The prefix for the firewall rule name, it will be appended by the IP address"
       }
     },
-    "startIpAddress": {
-      "type": "string",
-      "defaultValue": "",
-      "metadata": {
-        "description": "String of IP addresses to whitelist against a SQL server"
-      }
-    },
-    "endIpAddress": {
-      "type": "string",
-      "defaultValue": "",
-      "metadata": {
-        "description": "String of IP addresses to whitelist against a SQL server"
-      }
-    },
     "serverName": {
       "type": "string",
       "metadata": {
@@ -40,25 +26,37 @@
       "type": "array",
       "defaultValue": [],
       "metadata": {
-        "description": "Array of IP addresses to whitelist against a SQL server, these are azure IP addresses that are passed in using the reference function"
+        "description": "Array of IP azure addresses to whitelist against a SQL server, these are azure IP addresses that are passed in using the reference function"
       }
-    }
+    },
+    "sqlFirewallIpAddressesPredefined": {
+            "type": "array",
+            "defaultValue": [],
+            "metadata": {
+               "description": "Array of predefined IP addresses to whitelist against a SQL server, these are azure IP addresses that are passed in using the reference function"
+      }
+        }
   },
   "variables": {},
   "resources": [
     {
-      // This resource is used for pre-defined IP ranges.
-      "name": "[concat(parameters('serverName'), '/', parameters('firewallRuleNamePrefix'))]",
-      "condition": "[greater(length(parameters('startIpAddress')), 0)]",
+      // This resource deploys all the pre-defined IP ranges.
+      "name": "[concat(parameters('serverName'), '/', parameters('sqlFirewallIpAddressesPredefined')[copyIndex()].name)]",
+      "condition": "[greater(length(parameters('sqlFirewallIpAddressesPredefined')), 0)]",
       "type": "Microsoft.Sql/servers/firewallRules",
       "apiVersion": "2015-05-01-preview",
       "properties": {
-        "startIpAddress": "[parameters('startIpAddress')]",
-        "endIpAddress": "[parameters('endIpAddress')]"
+        "startIpAddress": "[parameters('sqlFirewallIpAddressesPredefined')[copyIndex()].startIpAddress]",
+        "endIpAddress": "[parameters('sqlFirewallIpAddressesPredefined')[copyIndex()].endIpAddress]"
+      },
+      "copy": {
+          "count": "[length(parameters('sqlFirewallIpAddressesPredefined'))]",
+          "name": "firewallrulecopy",
+          "mode": "Parallel"
       }
     },
     {
-      // This resource is used for azure resource IP addresses that are passed in using the reference function
+      // This resource deploys azure resource IP addresses that are passed in using the reference function
       "name": "[concat(parameters('serverName'), '/', parameters('firewallRuleNamePrefix'), if(greater(length(parameters('ipAddresses')), 0), parameters('ipAddresses')[copyIndex()], 'placeholder'))]",
       "condition": "[greater(length(parameters('ipAddresses')), 0)]",
       "type": "Microsoft.Sql/servers/firewallRules",


### PR DESCRIPTION
Reworked sql firewalls rules deployment so that the template loops through a whole list of pre-defined rules. This allows users to pass and loop through multiple SQL servers in their consuming template.