### PR TITLE
added functionality for replica databse deployment

### DIFF
--- a/ArmTemplates/keyvault-secret.json
+++ b/ArmTemplates/keyvault-secret.json
@@ -17,7 +17,7 @@
         {
             "name": "[concat(parameters('keyVaultName'), '/', parameters('secretName'))]",
             "type": "Microsoft.KeyVault/vaults/secrets",
-            "apiVersion": "2019-04-01",
+            "apiVersion": "2022-07-01",
             "properties": {
                 "value": "[parameters('secretValue')]"
             }

--- a/ArmTemplates/sql-database.json
+++ b/ArmTemplates/sql-database.json
@@ -3,18 +3,31 @@
     "contentVersion": "1.0.0.0",
     "parameters": {
         "databaseName": {
-            "type": "string"
+            "type": "string",
+            "metadata": {
+                "description": "(Required) Name of the SQL database to deploy."
+            }
         },
+        
         "sqlServerName": {
-            "type": "string"
+            "type": "string",
+            "metadata": {
+                "description": "(Required) Name of the SQL server to deploy this database to."
+            }
         },
         "elasticPoolName": {
             "type": "string",
-            "defaultValue": ""
+            "defaultValue": "",
+            "metadata": {
+                "description": "(Optional) Name of the elastic pool containing this database, used in the resource id to reference the elastic pool."
+            }
         },
         "databaseSkuName": {
             "type": "string",
-            "defaultValue": ""
+            "defaultValue": "",
+            "metadata": {
+                "description": "(Required) The database SKU names e.g. S0 or GP_S_Gen5_6. Not required if deployToElasticPool is true."
+            }
         },
         "databaseSizeBytes": {
             "type": "string",
@@ -31,28 +44,37 @@
                 "GeneralPurpose",
                 "BusinessCritical",
                 "Hyperscale"
-            ]
+            ],
+            "metadata": {
+                "description": "(Optional) The database SKU, equired if not using elastic pool."
+            }
         },
         "serverlessMinCapacity": {
             "type": "string",
-            "defaultValue": ""
+            "defaultValue": "",
+            "metadata": {
+                "description": "(Optional) Minimal capacity that database will always have allocated, if not paused To specify a decimal value, use the json() function."
+            }
         },
         "serverlessAutoPauseDelay": {
             "type": "string",
-            "defaultValue": "-1"
+            "defaultValue": "-1",
+            "metadata": {
+                "description": "(Optional) Time in minutes after which database is automatically paused. A value of -1 means that automatic pause is disabled."
+            }
         },
         "dataMaskingExemptPrincipals": {
             "type": "string",
             "defaultValue": "",
             "metadata": {
-                "description": "Semi-colon separated list of database principals who are exempt from the following data masking rules"
+                "description": "(Optional) Semi-colon separated list of database principals who are exempt from the following data masking rules."
             }
         },
         "dataMaskingRules": {
             "type": "array",
             "defaultValue": [],
             "metadata": {
-                "description": "Object array where object is of type DataMaskingRuleProperties: https://docs.microsoft.com/en-us/azure/templates/microsoft.sql/servers/databases/datamaskingpolicies/rules#DataMaskingRuleProperties"
+                "description": "(Optional) Object array where object is of type DataMaskingRuleProperties: https://docs.microsoft.com/en-us/azure/templates/microsoft.sql/servers/databases/datamaskingpolicies/rules#DataMaskingRuleProperties."
             }
         },
         "diagnosticsRetentionDays": {
@@ -61,29 +83,54 @@
             "minValue": 0,
             "maxValue": 365,
             "metadata": {
-                "descrtiption": "The number of days that diagnostic logs will be stored for. Default value is forever, max is 1 year."
+                "descrtiption": "(Optional) The number of days that diagnostic logs will be stored for. Default value is forever, max is 1 year."
             }
-    },
-    "logAnalyticsSubscriptionId": {
-      "type": "string",
-      "defaultValue": "[subscription().subscriptionId]",
-      "metadata": {
-        "description": "The id of the subscription for the Log Analytics Workspace. This defaults to the current subscription."
-      }
-    },
-    "logAnalyticsResourceGroup": {
-      "type": "string",
-      "defaultValue" : "[resourceGroup().name]",
-      "metadata": {
-        "description": "The resource group of the Log Analytics Workspace."
-      }
-    },
-    "logAnalyticsWorkspaceName": {
-      "type": "string",
-      "defaultValue" : "",
-      "metadata": {
-        "description": "The name of the Log Analytics Workspace."
-      }
+        },
+        "logAnalyticsSubscriptionId": {
+            "type": "string",
+            "defaultValue": "[subscription().subscriptionId]",
+            "metadata": {
+            "description": "(Optional) The id of the subscription for the Log Analytics Workspace used for diagnostics settings. This defaults to the current subscription."
+         }
+        },
+        "logAnalyticsResourceGroup": {
+            "type": "string",
+            "defaultValue" : "[resourceGroup().name]",
+            "metadata": {
+                "description": "(Optional) The resource group of the Log Analytics Workspace used for diagnostics settings."
+            }
+        },
+        "logAnalyticsWorkspaceName": {
+            "type": "string",
+            "defaultValue" : "",
+            "metadata": {
+                "description": "(Optional) The name of the Log Analytics Workspace used for diagnostics settings."
+            }
+        },
+        "createMode":{
+            "type": "string",
+            "defaultValue": "Default",
+            "allowedValues": [
+                "Default",
+                "Secondary"
+            ],
+            "metadata": {
+                "description": "(Optional) Specifies the mode of database creation, modes explained: https://learn.microsoft.com/en-us/azure/templates/microsoft.sql/servers/databases?pivots=deployment-language-arm-template#databaseproperties-1"
+            }
+        },
+        "sourceDatabaseId":{
+            "type": "string",
+            "defaultValue": "",
+            "metadata": {
+                "description": "(Optional) The resourceId of the source database associated with create operation of this database if createMode is not 'Default'."
+            }
+        },
+        "requestedBackupStorageRedundancy":{
+            "type": "string",
+            "defaultValue": "Geo",
+            "metadata": {
+                "description": "(Optional) The storage account type to be used to store backups for this database."
+            }
         }
     },
     "variables": {
@@ -97,7 +144,10 @@
                 "properties": {
                     "maxSizeBytes": "[parameters('databaseSizeBytes')]",
                     "minCapacity": "[parameters('serverlessMinCapacity')]",
-                    "autoPauseDelay": "[parameters('serverlessAutoPauseDelay')]"
+                    "autoPauseDelay": "[parameters('serverlessAutoPauseDelay')]",
+                    "createMode": "[parameters('createMode')]",
+                    "sourceDatabaseId": "[if(equals(parameters('createMode'),'Secondary'), parameters('sourceDatabaseId'), null())]",
+                    "requestedBackupStorageRedundancy": "[parameters('requestedBackupStorageRedundancy')]"
                 }
             },
             "elasticPool": {
@@ -132,6 +182,7 @@
             "resources": [
                 {
                     "name": "current",
+                    "condition": "[not(equals(parameters('createMode'),'Secondary'))]",
                     "type": "transparentDataEncryption",
                     "apiVersion": "2014-04-01",
                     "properties": {
@@ -201,5 +252,10 @@
             }
         }
     ],
-    "outputs": {}
+    "outputs": {
+        "sqlDatabaseResourceId": {
+            "type": "string",
+            "value": "[resourceId('Microsoft.Sql/servers/databases', parameters('sqlServerName'), parameters('databaseName'))]"
+        }
+    }
 }

--- a/ArmTemplates/sql-database.json
+++ b/ArmTemplates/sql-database.json
@@ -31,7 +31,10 @@
         },
         "databaseSizeBytes": {
             "type": "string",
-            "defaultValue": ""
+            "defaultValue": "",
+            "metadata": {
+                "description": "(Optional) The max size of the database expressed in bytes."
+            }
         },
         "databaseTier": {
             "type": "string",

--- a/ArmTemplates/sql-server-firewall-rules.json
+++ b/ArmTemplates/sql-server-firewall-rules.json
@@ -33,9 +33,9 @@
       "type": "array",
       "defaultValue": [],
       "metadata": {
-          "description": "Array of predefined IP addresses to whitelist against a SQL server, these are azure IP addresses that are passed in using the reference function"
+        "description": "Array of predefined IP addresses to whitelist against a SQL server, these are azure IP addresses that are passed in using the reference function"
       }
-        }
+    }
   },
   "variables": {},
   "resources": [
@@ -50,9 +50,9 @@
         "endIpAddress": "[parameters('sqlFirewallIpAddressesPredefined')[copyIndex()].endIpAddress]"
       },
       "copy": {
-          "count": "[length(parameters('sqlFirewallIpAddressesPredefined'))]",
-          "name": "firewallrulecopy",
-          "mode": "Parallel"
+        "count": "[length(parameters('sqlFirewallIpAddressesPredefined'))]",
+        "name": "firewallrulecopy",
+        "mode": "Parallel"
       }
     },
     {

--- a/ArmTemplates/sql-server-firewall-rules.json
+++ b/ArmTemplates/sql-server-firewall-rules.json
@@ -30,10 +30,10 @@
       }
     },
     "sqlFirewallIpAddressesPredefined": {
-            "type": "array",
-            "defaultValue": [],
-            "metadata": {
-               "description": "Array of predefined IP addresses to whitelist against a SQL server, these are azure IP addresses that are passed in using the reference function"
+      "type": "array",
+      "defaultValue": [],
+      "metadata": {
+          "description": "Array of predefined IP addresses to whitelist against a SQL server, these are azure IP addresses that are passed in using the reference function"
       }
         }
   },
@@ -44,7 +44,7 @@
       "name": "[concat(parameters('serverName'), '/', parameters('sqlFirewallIpAddressesPredefined')[copyIndex()].name)]",
       "condition": "[greater(length(parameters('sqlFirewallIpAddressesPredefined')), 0)]",
       "type": "Microsoft.Sql/servers/firewallRules",
-      "apiVersion": "2015-05-01-preview",
+      "apiVersion": "2022-05-01-preview",
       "properties": {
         "startIpAddress": "[parameters('sqlFirewallIpAddressesPredefined')[copyIndex()].startIpAddress]",
         "endIpAddress": "[parameters('sqlFirewallIpAddressesPredefined')[copyIndex()].endIpAddress]"
@@ -60,7 +60,7 @@
       "name": "[concat(parameters('serverName'), '/', parameters('firewallRuleNamePrefix'), if(greater(length(parameters('ipAddresses')), 0), parameters('ipAddresses')[copyIndex()], 'placeholder'))]",
       "condition": "[greater(length(parameters('ipAddresses')), 0)]",
       "type": "Microsoft.Sql/servers/firewallRules",
-      "apiVersion": "2015-05-01-preview",
+      "apiVersion": "2022-05-01-preview",
       "properties": {
         "startIpAddress": "[parameters('ipAddresses')[copyIndex()]]",
         "endIpAddress": "[parameters('ipAddresses')[copyIndex()]]"
@@ -75,7 +75,7 @@
       "name": "[concat(parameters('serverName'), '/', if(greater(length(parameters('subnetResourceIdList')), 0), last(split(parameters('subnetResourceIdList')[copyIndex()], '/')), 'placeholder'))]",
       "condition": "[greater(length(parameters('subnetResourceIdList')), 0)]",
       "type": "Microsoft.Sql/servers/virtualNetworkRules",
-      "apiVersion": "2015-05-01-preview",
+      "apiVersion": "2022-05-01-preview",
       "properties": {
         "virtualNetworkSubnetId": "[parameters('subnetResourceIdList')[copyIndex()]]"
       },

--- a/ArmTemplates/sql-server.json
+++ b/ArmTemplates/sql-server.json
@@ -5,7 +5,7 @@
     "sqlServerName": {
       "type": "string",
       "metadata": {
-        "description": "Name of the Azure SQL Server  instance"
+        "description": "(Required) Name of the Azure SQL Server instance"
       }
     },
     "sqlServerLocation": {
@@ -14,63 +14,66 @@
       "allowedValues": [
         "westeurope",
         "northeurope"
-      ]
+      ],
+      "metadata": {
+        "description": "(Required) The region used to deploy resouce."
+      }
     },
     "sqlServerAdminUserName": {
       "type": "string",
       "metadata": {
-        "description": "The Azure SQL Server Administrator (SA) username "
+        "description": "(Required) The Azure SQL Server Administrator (SA) username."
       }
     },
     "sqlServerAdminPassword": {
       "type": "securestring",
       "metadata": {
-        "description": "The Azure SQL Server Administrator (SA) password"
+        "description": "(Required) The Azure SQL Server Administrator (SA) password."
       }
     },
     "sqlServerActiveDirectoryAdminLogin": {
       "type": "string",
       "metadata": {
-        "description": "The active directory admin that will be assigned to the SQL server"
+        "description": "(Required) The active directory admin that will be assigned to the SQL server"
       }
     },
     "sqlServerActiveDirectoryAdminObjectId": {
       "type": "string",
       "metadata": {
-        "description": "The object id of the active directory admin that will be assigned to the SQL server"
+        "description": "(Required) The object id of the active directory admin that will be assigned to the SQL server"
       }
     },
     "threatDetectionEmailAddress": {
       "type": "string",
       "metadata": {
-        "description": "The email address that threat alerts will be sent to"
+        "description": "(Required) The email address that threat alerts will be sent to"
       }
     },
     "sqlStorageAccountName": {
       "type": "string",
       "metadata": {
-        "description": "Name of the SQL logs storage account for the environment"
+        "description": "(Required) Name of the SQL logs storage account for the environment"
       }
     },
     "logAnalyticsWorkspaceName": {
       "type": "string",
       "defaultValue": "",
       "metadata": {
-        "description": "The name of the OMS workspace that will collect audit events"
+        "description": "(Optional) The name of the OMS workspace that will collect audit events"
       }
     },
     "logAnalyticsWorkspaceResourceGroupName": {
       "type": "string",
       "defaultValue": "",
       "metadata": {
-        "description": "The name of the OMS workspace resource group that will collect audit events"
+        "description": "(Optional) The name of the OMS workspace resource group that will collect audit events"
       }
     },
     "logAnalyticsWorkspaceSubscriptionId": {
       "type": "string",
       "defaultValue": "",
       "metadata": {
-        "description": "The id of the OMS workspace subscription that will collect audit events"
+        "description": "(Optional) The id of the OMS workspace subscription that will collect audit events"
       }
     }
   },


### PR DESCRIPTION
- Added properties and parameters for ability for secondary database to be deployed.
- Modified descriptions to included whether parameter is Required or Optional.
- Added output for sqlDatabaseResourceId, this allows for the main databases resource ID be passed in as the sourceDatabaseId on the replica database.
- Added condition on the transparentDataEncryption. When using a secondary database it inherits the status from the primary DB. If you try changing the status you get an inheritance error, so condition has been added to prevent it deploying when createMode is secondary.
- Updated the apiVersion for the sql server firewall rule resources