### PR TITLE
changed http version default to 2.0

### DIFF
--- a/ArmTemplates/app-service.json
+++ b/ArmTemplates/app-service.json
@@ -103,7 +103,7 @@
     },
     "http20Enabled": {
       "type": "bool",
-      "defaultValue": false
+      "defaultValue": true
     },
     "ftpsState": {
       "type": "string",


### PR DESCRIPTION
This change is required to update the default http version to 2.0 .

The old resac infra is set to 2.0 and we should ensure the new infrastructure is too, find provider (service that also uses this building block) manually sets this in it's ARM template. 

Changing default as this should be the default across our services.
