### PR TITLE
Update Storage Account Connection String Outputs To Support Key Rotation

### DIFF
--- a/ArmTemplates/storage-account-arm.json
+++ b/ArmTemplates/storage-account-arm.json
@@ -220,9 +220,13 @@
       "type": "string",
       "value": "[listKeys(resourceId('Microsoft.Storage/storageAccounts', parameters('storageAccountName')), providers('Microsoft.Storage', 'storageAccounts').apiVersions[0]).keys[0].value]"
     },
-    "storageConnectionString": {
+    "storageConnectionStringKey1": {
       "type": "string",
       "value": "[concat('DefaultEndpointsProtocol=https;AccountName=', parameters('storageAccountName'), ';AccountKey=', listKeys(resourceId('Microsoft.Storage/storageAccounts', parameters('storageAccountName')), providers('Microsoft.Storage', 'storageAccounts').apiVersions[0]).keys[0].value, ';EndpointSuffix=core.windows.net')]"
+    },
+    "storageConnectionStringKey2": {
+      "type": "string",
+      "value": "[concat('DefaultEndpointsProtocol=https;AccountName=', parameters('storageAccountName'), ';AccountKey=', listKeys(resourceId('Microsoft.Storage/storageAccounts', parameters('storageAccountName')), providers('Microsoft.Storage', 'storageAccounts').apiVersions[0]).keys[1].value, ';EndpointSuffix=core.windows.net')]"
     },
     "storagePrimaryEndpointsBlob": {
       "type": "string",


### PR DESCRIPTION
The storageConnectionString output has been renamed to more clearly indicate that it is producing the string with access key1 for a storage account. Additionally, another storageConnectionString output has been created for key2, which produces the string with key2 from a storage account.