### PR TITLE
Change storage account minimum TLS version to 1.2

### DIFF
--- a/ArmTemplates/storage-account-arm.json
+++ b/ArmTemplates/storage-account-arm.json
@@ -110,10 +110,8 @@
     },
     "minimumTlsVersion": {
       "type": "string",
-      "defaultValue": "TLS1_0",
+      "defaultValue": "TLS1_2",
       "allowedValues": [
-        "TLS1_0",
-        "TLS1_0",
         "TLS1_2"
       ]
     },


### PR DESCRIPTION
This change enforces TLS 1.2 at the storage account template level. All the services consuming this template have already had their defaults overridden to use 1.2 so this change will standardise the config for any new resources added to the services in the future.