### PR TITLE
Add support for rotating access keys for SQL audit log storage accounts

### DIFF
--- a/ArmTemplates/sql-server.json
+++ b/ArmTemplates/sql-server.json
@@ -93,9 +93,7 @@
   "variables": {
     "auditPolicyName": "[concat(parameters('sqlServerName'), '-DefaultAuditPolicy')]",
     "securityAlertPolicyName": "[concat(parameters('sqlServerName'), '-DefaultSecurityAlert')]",
-    "diagnosticSettingName": "SQLSecurityAuditEvents_3d229c42-c7e7-4c97-9a99-ec0d0d8b86c1",
-    "storageAccountAccessKey1": "[listKeys(resourceId('Microsoft.Storage/storageAccounts', parameters('sqlStorageAccountName')), providers('Microsoft.Storage', 'storageAccounts').apiVersions[0]).keys[0].value]",
-    "storageAccountAccessKey2": "[listKeys(resourceId('Microsoft.Storage/storageAccounts', parameters('sqlStorageAccountName')), providers('Microsoft.Storage', 'storageAccounts').apiVersions[0]).keys[1].value]"
+    "diagnosticSettingName": "SQLSecurityAuditEvents_3d229c42-c7e7-4c97-9a99-ec0d0d8b86c1"
   },
   "resources": [
     {
@@ -152,7 +150,7 @@
           "properties": {
             "state": "Enabled",
             "storageEndpoint": "[concat('https://', parameters('sqlStorageAccountName'), '.blob.core.windows.net/')]",
-            "storageAccountAccessKey": "[if(parameters('isStorageSecondaryKeyInUse'),variables('StorageAccountAccessKey2'),variables('StorageAccountAccessKey1'))]",
+            "storageAccountAccessKey": "[if(parameters('isStorageSecondaryKeyInUse'), listKeys(resourceId('Microsoft.Storage/storageAccounts', parameters('sqlStorageAccountName')), providers('Microsoft.Storage', 'storageAccounts').apiVersions[0]).keys[0].value, listKeys(resourceId('Microsoft.Storage/storageAccounts', parameters('sqlStorageAccountName')), providers('Microsoft.Storage', 'storageAccounts').apiVersions[0]).keys[1].value)]",
             "isStorageSecondaryKeyInUse": "[parameters('isStorageSecondaryKeyInUse')]",
             "auditActionsAndGroups": [
               "BATCH_COMPLETED_GROUP",

--- a/ArmTemplates/sql-server.json
+++ b/ArmTemplates/sql-server.json
@@ -55,6 +55,12 @@
         "description": "(Required) Name of the SQL logs storage account for the environment"
       }
     },
+    "isStorageSecondaryKeyInUse": {
+      "type": "bool",
+      "metadata": {
+        "description": "Is the secondary storage account key being used"
+      }
+    },
     "logAnalyticsWorkspaceName": {
       "type": "string",
       "defaultValue": "",
@@ -144,8 +150,8 @@
           "properties": {
             "state": "Enabled",
             "storageEndpoint": "[concat('https://', parameters('sqlStorageAccountName'), '.blob.core.windows.net/')]",
-            "storageAccountAccessKey": "[listKeys(resourceId('Microsoft.Storage/storageAccounts', parameters('sqlStorageAccountName')), providers('Microsoft.Storage', 'storageAccounts').apiVersions[0]).keys[0].value]",
-            "retentionDays": 90,
+            "storageAccountAccessKey": "[if(parameters('isStorageSecondaryKeyInUse'), listKeys(resourceId('Microsoft.Storage/storageAccounts', parameters('sqlStorageAccountName')), providers('Microsoft.Storage', 'storageAccounts').apiVersions[0]).keys[0].value, listKeys(resourceId('Microsoft.Storage/storageAccounts', parameters('sqlStorageAccountName')), providers('Microsoft.Storage', 'storageAccounts').apiVersions[0]).keys[1].value)]",
+            "isStorageSecondaryKeyInUse": "[parameters('isStorageSecondaryKeyInUse')]",
             "auditActionsAndGroups": [
               "BATCH_COMPLETED_GROUP",
               "SUCCESSFUL_DATABASE_AUTHENTICATION_GROUP",

--- a/ArmTemplates/sql-server.json
+++ b/ArmTemplates/sql-server.json
@@ -55,6 +55,12 @@
         "description": "(Required) Name of the SQL logs storage account for the environment"
       }
     },
+    "isStorageSecondaryKeyInUse": {
+      "type": "bool",
+      "metadata": {
+        "description": "Is the secondary storage account key being used"
+      }
+    },
     "logAnalyticsWorkspaceName": {
       "type": "string",
       "defaultValue": "",
@@ -74,6 +80,13 @@
       "defaultValue": "",
       "metadata": {
         "description": "(Optional) The id of the OMS workspace subscription that will collect audit events"
+      }
+    },
+    "enableSqlServerVulnerabilityAssessment": {
+      "type": "string",
+      "defaultValue": "Enabled",
+      "metadata": {
+        "description": "Enables SQL vulnerability assessment scanning"
       }
     }
   },
@@ -137,8 +150,8 @@
           "properties": {
             "state": "Enabled",
             "storageEndpoint": "[concat('https://', parameters('sqlStorageAccountName'), '.blob.core.windows.net/')]",
-            "storageAccountAccessKey": "[listKeys(resourceId('Microsoft.Storage/storageAccounts', parameters('sqlStorageAccountName')), providers('Microsoft.Storage', 'storageAccounts').apiVersions[0]).keys[0].value]",
-            "retentionDays": 90,
+            "storageAccountAccessKey": "[if(parameters('isStorageSecondaryKeyInUse'), listKeys(resourceId('Microsoft.Storage/storageAccounts', parameters('sqlStorageAccountName')), providers('Microsoft.Storage', 'storageAccounts').apiVersions[0]).keys[0].value, listKeys(resourceId('Microsoft.Storage/storageAccounts', parameters('sqlStorageAccountName')), providers('Microsoft.Storage', 'storageAccounts').apiVersions[0]).keys[1].value)]",
+            "isStorageSecondaryKeyInUse": "[parameters('isStorageSecondaryKeyInUse')]",
             "auditActionsAndGroups": [
               "BATCH_COMPLETED_GROUP",
               "SUCCESSFUL_DATABASE_AUTHENTICATION_GROUP",
@@ -178,7 +191,21 @@
           "dependsOn": [
             "[concat('Microsoft.Sql/servers/', parameters('sqlServerName'))]"
           ]
+        },
+        {
+          "type": "Microsoft.Sql/servers/sqlVulnerabilityAssessments",
+          "apiVersion": "2023-05-01-preview",
+          "name": "[concat(parameters('sqlServerName'), '/Default')]",
+          "dependsOn": [
+            "[concat('Microsoft.Sql/servers/', parameters('sqlServerName'))]",
+            "[concat('Microsoft.Sql/servers/', parameters('sqlServerName'), '/auditingSettings/', variables('AuditPolicyName'))]",
+            "[concat('Microsoft.Sql/servers/', parameters('sqlServerName'), '/securityAlertPolicies/', variables('securityAlertPolicyName'))]"
+          ],
+          "properties": {
+            "state": "[parameters('enableSqlServerVulnerabilityAssessment')]"
+          }
         }
+
       ]
     }
   ],

--- a/ArmTemplates/sql-server.json
+++ b/ArmTemplates/sql-server.json
@@ -55,22 +55,10 @@
         "description": "(Required) Name of the SQL logs storage account for the environment"
       }
     },
-    "sqlStorageAccountAccessKey1": {
-      "type": "string",
-      "metadata": {
-        "description": "Primary access key for SQL to log to storage accounts for the environment"
-      }
-    },
     "isStorageSecondaryKeyInUse": {
       "type": "bool",
       "metadata": {
         "description": "Is the secondary storage account key being used"
-      }
-    },
-    "sqlStorageAccountAccessKey2": {
-      "type": "string",
-      "metadata": {
-        "description": "Secondary access key for SQL to log to storage accounts for the environment"
       }
     },
     "logAnalyticsWorkspaceName": {
@@ -105,7 +93,9 @@
   "variables": {
     "auditPolicyName": "[concat(parameters('sqlServerName'), '-DefaultAuditPolicy')]",
     "securityAlertPolicyName": "[concat(parameters('sqlServerName'), '-DefaultSecurityAlert')]",
-    "diagnosticSettingName": "SQLSecurityAuditEvents_3d229c42-c7e7-4c97-9a99-ec0d0d8b86c1"
+    "diagnosticSettingName": "SQLSecurityAuditEvents_3d229c42-c7e7-4c97-9a99-ec0d0d8b86c1",
+    "storageAccountAccessKey1": "[listKeys(resourceId('Microsoft.Storage/storageAccounts', parameters('sqlStorageAccountName')), providers('Microsoft.Storage', 'storageAccounts').apiVersions[0]).keys[0].value]",
+    "storageAccountAccessKey2": "[listKeys(resourceId('Microsoft.Storage/storageAccounts', parameters('sqlStorageAccountName')), providers('Microsoft.Storage', 'storageAccounts').apiVersions[0]).keys[1].value]"
   },
   "resources": [
     {
@@ -162,7 +152,7 @@
           "properties": {
             "state": "Enabled",
             "storageEndpoint": "[concat('https://', parameters('sqlStorageAccountName'), '.blob.core.windows.net/')]",
-            "storageAccountAccessKey": "[if(parameters('isStorageSecondaryKeyInUse'),parameters('sqlStorageAccountAccessKey2'),parameters('sqlStorageAccountAccessKey1'))]",
+            "storageAccountAccessKey": "[if(parameters('isStorageSecondaryKeyInUse'),variables('StorageAccountAccessKey2'),variables('StorageAccountAccessKey1'))]",
             "isStorageSecondaryKeyInUse": "[parameters('isStorageSecondaryKeyInUse')]",
             "auditActionsAndGroups": [
               "BATCH_COMPLETED_GROUP",

--- a/ArmTemplates/sql-server.json
+++ b/ArmTemplates/sql-server.json
@@ -55,6 +55,24 @@
         "description": "(Required) Name of the SQL logs storage account for the environment"
       }
     },
+    "sqlStorageAccountAccessKey1": {
+      "type": "string",
+      "metadata": {
+        "description": "Primary access key for SQL to log to storage accounts for the environment"
+      }
+    },
+    "isStorageSecondaryKeyInUse": {
+      "type": "bool",
+      "metadata": {
+        "description": "Is the secondary storage account key being used"
+      }
+    },
+    "sqlStorageAccountAccessKey2": {
+      "type": "string",
+      "metadata": {
+        "description": "Secondary access key for SQL to log to storage accounts for the environment"
+      }
+    },
     "logAnalyticsWorkspaceName": {
       "type": "string",
       "defaultValue": "",
@@ -137,8 +155,8 @@
           "properties": {
             "state": "Enabled",
             "storageEndpoint": "[concat('https://', parameters('sqlStorageAccountName'), '.blob.core.windows.net/')]",
-            "storageAccountAccessKey": "[listKeys(resourceId('Microsoft.Storage/storageAccounts', parameters('sqlStorageAccountName')), providers('Microsoft.Storage', 'storageAccounts').apiVersions[0]).keys[0].value]",
-            "retentionDays": 90,
+            "storageAccountAccessKey": "[if(parameters('isStorageSecondaryKeyInUse'),parameters('sqlStorageAccountAccessKey2'),parameters('sqlStorageAccountAccessKey1'))]",
+            "isStorageSecondaryKeyInUse": "[parameters('isStorageSecondaryKeyInUse')]",
             "auditActionsAndGroups": [
               "BATCH_COMPLETED_GROUP",
               "SUCCESSFUL_DATABASE_AUTHENTICATION_GROUP",

--- a/ArmTemplates/storage-account-arm.json
+++ b/ArmTemplates/storage-account-arm.json
@@ -214,10 +214,6 @@
     }
   ],
   "outputs": {
-    "storageKey": {
-      "type": "string",
-      "value": "[listKeys(resourceId('Microsoft.Storage/storageAccounts', parameters('storageAccountName')), providers('Microsoft.Storage', 'storageAccounts').apiVersions[0]).keys[0].value]"
-    },
     "storageConnectionStringKey1": {
       "type": "string",
       "value": "[concat('DefaultEndpointsProtocol=https;AccountName=', parameters('storageAccountName'), ';AccountKey=', listKeys(resourceId('Microsoft.Storage/storageAccounts', parameters('storageAccountName')), providers('Microsoft.Storage', 'storageAccounts').apiVersions[0]).keys[0].value, ';EndpointSuffix=core.windows.net')]"

--- a/ArmTemplates/storage-account-arm.json
+++ b/ArmTemplates/storage-account-arm.json
@@ -216,9 +216,13 @@
     }
   ],
   "outputs": {
-    "storageKey": {
+    "sqlStorageAccountAccessKey1": {
       "type": "string",
       "value": "[listKeys(resourceId('Microsoft.Storage/storageAccounts', parameters('storageAccountName')), providers('Microsoft.Storage', 'storageAccounts').apiVersions[0]).keys[0].value]"
+    },
+    "sqlStorageAccountAccessKey2": {
+      "type": "string",
+      "value": "[listKeys(resourceId('Microsoft.Storage/storageAccounts', parameters('storageAccountName')), providers('Microsoft.Storage', 'storageAccounts').apiVersions[0]).keys[1].value]"
     },
     "storageConnectionStringKey1": {
       "type": "string",

--- a/ArmTemplates/storage-account-arm.json
+++ b/ArmTemplates/storage-account-arm.json
@@ -110,10 +110,8 @@
     },
     "minimumTlsVersion": {
       "type": "string",
-      "defaultValue": "TLS1_0",
+      "defaultValue": "TLS1_2",
       "allowedValues": [
-        "TLS1_0",
-        "TLS1_0",
         "TLS1_2"
       ]
     },
@@ -216,10 +214,6 @@
     }
   ],
   "outputs": {
-    "storageKey": {
-      "type": "string",
-      "value": "[listKeys(resourceId('Microsoft.Storage/storageAccounts', parameters('storageAccountName')), providers('Microsoft.Storage', 'storageAccounts').apiVersions[0]).keys[0].value]"
-    },
     "storageConnectionStringKey1": {
       "type": "string",
       "value": "[concat('DefaultEndpointsProtocol=https;AccountName=', parameters('storageAccountName'), ';AccountKey=', listKeys(resourceId('Microsoft.Storage/storageAccounts', parameters('storageAccountName')), providers('Microsoft.Storage', 'storageAccounts').apiVersions[0]).keys[0].value, ';EndpointSuffix=core.windows.net')]"

--- a/ArmTemplates/storage-account-arm.json
+++ b/ArmTemplates/storage-account-arm.json
@@ -214,14 +214,6 @@
     }
   ],
   "outputs": {
-    "sqlStorageAccountAccessKey1": {
-      "type": "string",
-      "value": "[listKeys(resourceId('Microsoft.Storage/storageAccounts', parameters('storageAccountName')), providers('Microsoft.Storage', 'storageAccounts').apiVersions[0]).keys[0].value]"
-    },
-    "sqlStorageAccountAccessKey2": {
-      "type": "string",
-      "value": "[listKeys(resourceId('Microsoft.Storage/storageAccounts', parameters('storageAccountName')), providers('Microsoft.Storage', 'storageAccounts').apiVersions[0]).keys[1].value]"
-    },
     "storageConnectionStringKey1": {
       "type": "string",
       "value": "[concat('DefaultEndpointsProtocol=https;AccountName=', parameters('storageAccountName'), ';AccountKey=', listKeys(resourceId('Microsoft.Storage/storageAccounts', parameters('storageAccountName')), providers('Microsoft.Storage', 'storageAccounts').apiVersions[0]).keys[0].value, ';EndpointSuffix=core.windows.net')]"


### PR DESCRIPTION
This change updates and adds outputs for both key1 & key2 for storing the SQL audit logs to storage accounts. It also adds the logic to support the switching of between key1 & key2 by utilising the "isStorageSecondaryKeyInUse" parameter.