### PR TITLE
Add functionality to switch to key2 for storing SQL audit logs

### DIFF
--- a/ArmTemplates/sql-server.json
+++ b/ArmTemplates/sql-server.json
@@ -55,6 +55,12 @@
         "description": "(Required) Name of the SQL logs storage account for the environment"
       }
     },
+    "isStorageSecondaryKeyInUse": {
+      "type": "bool",
+      "metadata": {
+        "description": "Is the secondary storage account key being used"
+      }
+    },
     "logAnalyticsWorkspaceName": {
       "type": "string",
       "defaultValue": "",
@@ -144,7 +150,8 @@
           "properties": {
             "state": "Enabled",
             "storageEndpoint": "[concat('https://', parameters('sqlStorageAccountName'), '.blob.core.windows.net/')]",
-            "storageAccountAccessKey": "[listKeys(resourceId('Microsoft.Storage/storageAccounts', parameters('sqlStorageAccountName')), providers('Microsoft.Storage', 'storageAccounts').apiVersions[0]).keys[0].value]",
+            "storageAccountAccessKey": "[if(parameters('isStorageSecondaryKeyInUse'), listKeys(resourceId('Microsoft.Storage/storageAccounts', parameters('sqlStorageAccountName')), providers('Microsoft.Storage', 'storageAccounts').apiVersions[0]).keys[0].value, listKeys(resourceId('Microsoft.Storage/storageAccounts', parameters('sqlStorageAccountName')), providers('Microsoft.Storage', 'storageAccounts').apiVersions[0]).keys[1].value)]",
+            "isStorageSecondaryKeyInUse": "[parameters('isStorageSecondaryKeyInUse')]",
             "retentionDays": 90,
             "auditActionsAndGroups": [
               "BATCH_COMPLETED_GROUP",

--- a/ArmTemplates/storage-account-arm.json
+++ b/ArmTemplates/storage-account-arm.json
@@ -214,10 +214,6 @@
     }
   ],
   "outputs": {
-    "storageKey": {
-      "type": "string",
-      "value": "[listKeys(resourceId('Microsoft.Storage/storageAccounts', parameters('storageAccountName')), providers('Microsoft.Storage', 'storageAccounts').apiVersions[0]).keys[0].value]"
-    },
     "storageConnectionStringKey1": {
       "type": "string",
       "value": "[concat('DefaultEndpointsProtocol=https;AccountName=', parameters('storageAccountName'), ';AccountKey=', listKeys(resourceId('Microsoft.Storage/storageAccounts', parameters('storageAccountName')), providers('Microsoft.Storage', 'storageAccounts').apiVersions[0]).keys[0].value, ';EndpointSuffix=core.windows.net')]"


### PR DESCRIPTION
Adds functionality for the SQL server template to switch between key1 & key2 when storing SQL auditing logs. The switching is done by modifying the variable "isStorageSecondaryKeyInUse" within Azure DevOps variable groups.

Additionally, I've removed an outdated output "storageKey" from storage account that is no longer being used.