### PR TITLE
Update SQL server template to support audit log key rotations

### DIFF
--- a/ArmTemplates/sql-server.json
+++ b/ArmTemplates/sql-server.json
@@ -57,6 +57,7 @@
     },
     "isStorageSecondaryKeyInUse": {
       "type": "bool",
+      "defaultValue": false,
       "metadata": {
         "description": "Is the secondary storage account key being used"
       }
@@ -150,7 +151,7 @@
           "properties": {
             "state": "Enabled",
             "storageEndpoint": "[concat('https://', parameters('sqlStorageAccountName'), '.blob.core.windows.net/')]",
-            "storageAccountAccessKey": "[if(parameters('isStorageSecondaryKeyInUse'), listKeys(resourceId('Microsoft.Storage/storageAccounts', parameters('sqlStorageAccountName')), providers('Microsoft.Storage', 'storageAccounts').apiVersions[0]).keys[0].value, listKeys(resourceId('Microsoft.Storage/storageAccounts', parameters('sqlStorageAccountName')), providers('Microsoft.Storage', 'storageAccounts').apiVersions[0]).keys[1].value)]",
+            "storageAccountAccessKey": "[if(parameters('isStorageSecondaryKeyInUse'), listKeys(resourceId('Microsoft.Storage/storageAccounts', parameters('sqlStorageAccountName')), providers('Microsoft.Storage', 'storageAccounts').apiVersions[0]).keys[1].value, listKeys(resourceId('Microsoft.Storage/storageAccounts', parameters('sqlStorageAccountName')), providers('Microsoft.Storage', 'storageAccounts').apiVersions[0]).keys[0].value)]",
             "isStorageSecondaryKeyInUse": "[parameters('isStorageSecondaryKeyInUse')]",
             "retentionDays": 90,
             "auditActionsAndGroups": [


### PR DESCRIPTION
Adds the parameter "isStorageSecondaryKeyInUse" which is used to switch between key1 and key2 when storing SQL audit logs to a storage account. Additionally adds the logic to enable the "storageAccountAccessKey" property to switch between these two keys.