### PR TITLE
Disable App Service & Function App FTP & SCM Basic Authentication

### DIFF
--- a/ArmTemplates/app-service.json
+++ b/ArmTemplates/app-service.json
@@ -185,6 +185,13 @@
     "healthCheckPath": {
       "type": "string",
       "defaultValue": ""
+    },
+    "allowBasicAuth": {
+      "type": "bool",
+      "defaultvalue": false,
+      "metadata": {
+        "description": "Used for allowing SCM & FTP basic auth publishing"
+      }
     }
   },
   "variables": {
@@ -357,6 +364,28 @@
             }
           }
         ]
+      }
+    },
+    {
+      "type": "Microsoft.Web/sites/basicPublishingCredentialsPolicies",
+      "apiVersion": "2024-04-01",
+      "name": "[concat(parameters('appServiceName'), '/ftp')]",
+      "dependsOn": [
+        "[parameters('appServiceName')]"
+      ],
+      "properties": {
+        "allow": "[parameters('allowBasicAuth')]"
+      }
+    },
+    {
+      "type": "Microsoft.Web/sites/basicPublishingCredentialsPolicies",
+      "apiVersion": "2024-04-01",
+      "name": "[concat(parameters('appServiceName'), '/scm')]",
+      "dependsOn": [
+        "[parameters('appServiceName')]"
+      ],
+      "properties": {
+        "allow": "[parameters('allowBasicAuth')]"
       }
     }
   ],

--- a/ArmTemplates/function-app.json
+++ b/ArmTemplates/function-app.json
@@ -106,6 +106,13 @@
     "healthCheckPath": {
       "type": "string",
       "defaultValue": ""
+    },
+    "allowBasicAuth": {
+      "type": "bool",
+      "defaultvalue": false,
+      "metadata": {
+        "description": "Used for allowing SCM & FTP basic auth publishing"
+      }
     }
   },
   "variables": {
@@ -209,6 +216,28 @@
             }
           }
         ]
+      }
+    },
+    {
+      "type": "Microsoft.Web/sites/basicPublishingCredentialsPolicies",
+      "apiVersion": "2024-04-01",
+      "name": "[concat(parameters('functionAppName'), '/ftp')]",
+      "dependsOn": [
+        "[parameters('functionAppName')]"
+      ],
+      "properties": {
+        "allow": "[parameters('allowBasicAuth')]"
+      }
+    },
+    {
+      "type": "Microsoft.Web/sites/basicPublishingCredentialsPolicies",
+      "apiVersion": "2024-04-01",
+      "name": "[concat(parameters('functionAppName'), '/scm')]",
+      "dependsOn": [
+        "[parameters('functionAppName')]"
+      ],
+      "properties": {
+        "allow": "[parameters('allowBasicAuth')]"
       }
     }
   ],


### PR DESCRIPTION
This update addresses ITHC recommendations by disabling FTP and SCM basic auth publishing credential config of function apps & app services. These resources do not use these types of authentication so this config should be disabled by default.

**Changes:**

- Added configuration to ARM templates to disable basic authentication for FTP and SCM.

- Set the default values for these authentication methods to "Disabled."
