### PR TITLE
Update Retiring SQL API Versions

### DIFF
--- a/ArmTemplates/sql-database.json
+++ b/ArmTemplates/sql-database.json
@@ -187,9 +187,9 @@
                     "name": "current",
                     "condition": "[not(equals(parameters('createMode'),'Secondary'))]",
                     "type": "transparentDataEncryption",
-                    "apiVersion": "2014-04-01",
+                    "apiVersion": "2024-05-01-preview",
                     "properties": {
-                        "status": "Enabled"
+                        "state": "Enabled"
                     },
                     "dependsOn": [
                         "[parameters('databaseName')]"
@@ -237,7 +237,7 @@
             "name": "[concat(parameters('sqlServerName'), '/', parameters('databaseName'), '/Default')]",
             "condition": "[greater(length(parameters('dataMaskingRules')), 0)]",
             "type": "Microsoft.Sql/servers/databases/dataMaskingPolicies",
-            "apiVersion": "2014-04-01",
+            "apiVersion": "2024-05-01-preview",
             "properties": {
                 "dataMaskingState": "Enabled",
                 "exemptPrincipals": "[parameters('dataMaskingExemptPrincipals')]"
@@ -247,7 +247,7 @@
             "name": "[concat(parameters('sqlServerName'), '/', parameters('databaseName'), '/Default/', if(greater(length(parameters('dataMaskingRules')), 0), concat(parameters('dataMaskingRules')[copyIndex()].schemaName, parameters('dataMaskingRules')[copyIndex()].tableName, parameters('dataMaskingRules')[copyIndex()].columnName),'placeholder'))]",
             "condition": "[greater(length(parameters('dataMaskingRules')), 0)]",
             "type": "Microsoft.Sql/servers/databases/dataMaskingPolicies/rules",
-            "apiVersion": "2014-04-01",
+            "apiVersion": "2024-05-01-preview",
             "properties": "[parameters('dataMaskingRules')[copyIndex()]]",
             "copy": {
                 "name": "dataMaskingRuleCopy",

--- a/ArmTemplates/sql-database.json.bak
+++ b/ArmTemplates/sql-database.json.bak
@@ -112,9 +112,9 @@
                 {
                     "name": "current",
                     "type": "transparentDataEncryption",
-                    "apiVersion": "2014-04-01",
+                    "apiVersion": "2024-05-01-preview",
                     "properties": {
-                        "status": "Enabled"
+                        "state": "Enabled"
                     },
                     "dependsOn": [
                         "[parameters('databaseName')]"
@@ -126,7 +126,7 @@
             "name": "[concat(parameters('sqlServerName'), '/', parameters('databaseName'), '/Default')]",
             "condition": "[greater(length(parameters('dataMaskingRules')), 0)]",
             "type": "Microsoft.Sql/servers/databases/dataMaskingPolicies",
-            "apiVersion": "2014-04-01",
+            "apiVersion": "2024-05-01-preview",
             "properties": {
                 "dataMaskingState": "Enabled",
                 "exemptPrincipals": "[parameters('dataMaskingExemptPrincipals')]"
@@ -136,7 +136,7 @@
             "name": "[concat(parameters('sqlServerName'), '/', parameters('databaseName'), '/Default/', if(greater(length(parameters('dataMaskingRules')), 0), concat(parameters('dataMaskingRules')[copyIndex()].schemaName, parameters('dataMaskingRules')[copyIndex()].tableName, parameters('dataMaskingRules')[copyIndex()].columnName),'placeholder'))]",
             "condition": "[greater(length(parameters('dataMaskingRules')), 0)]",
             "type": "Microsoft.Sql/servers/databases/dataMaskingPolicies/rules",
-            "apiVersion": "2014-04-01",
+            "apiVersion": "2024-05-01-preview",
             "properties": "[parameters('dataMaskingRules')[copyIndex()]]",
             "copy": {
                 "name": "dataMaskingRuleCopy",

--- a/ArmTemplates/sql-server-elastic-pool.json
+++ b/ArmTemplates/sql-server-elastic-pool.json
@@ -34,7 +34,7 @@
   "resources": [
     {
       "type": "Microsoft.Sql/servers/elasticpools",
-      "apiVersion": "2014-04-01",
+      "apiVersion": "2024-05-01-preview",
       "name": "[concat(parameters('sqlServerName'), '/', parameters('elasticPoolName'))]",
       "location": "[resourceGroup().location]",
       "properties": {

--- a/ArmTemplates/sql-server.json
+++ b/ArmTemplates/sql-server.json
@@ -247,7 +247,7 @@
         {
           "type": "administrators",
           "name": "activeDirectory",
-          "apiVersion": "2014-04-01-preview",
+          "apiVersion": "2024-05-01-preview",
           "location": "[parameters('sqlServerLocation')]",
           "properties": {
             "administratorType": "ActiveDirectory",

--- a/templates/sql-database.json
+++ b/templates/sql-database.json
@@ -112,7 +112,7 @@
                 {
                     "name": "current",
                     "type": "transparentDataEncryption",
-                    "apiVersion": "2014-04-01",
+                    "apiVersion": "2024-05-01-preview",
                     "properties": {
                         "status": "Enabled"
                     },
@@ -126,7 +126,7 @@
             "name": "[concat(parameters('sqlServerName'), '/', parameters('databaseName'), '/Default')]",
             "condition": "[greater(length(parameters('dataMaskingRules')), 0)]",
             "type": "Microsoft.Sql/servers/databases/dataMaskingPolicies",
-            "apiVersion": "2014-04-01",
+            "apiVersion": "2024-05-01-preview",
             "properties": {
                 "dataMaskingState": "Enabled",
                 "exemptPrincipals": "[parameters('dataMaskingExemptPrincipals')]"
@@ -136,7 +136,7 @@
             "name": "[concat(parameters('sqlServerName'), '/', parameters('databaseName'), '/Default/', if(greater(length(parameters('dataMaskingRules')), 0), concat(parameters('dataMaskingRules')[copyIndex()].schemaName, parameters('dataMaskingRules')[copyIndex()].tableName, parameters('dataMaskingRules')[copyIndex()].columnName),'placeholder'))]",
             "condition": "[greater(length(parameters('dataMaskingRules')), 0)]",
             "type": "Microsoft.Sql/servers/databases/dataMaskingPolicies/rules",
-            "apiVersion": "2014-04-01",
+            "apiVersion": "2024-05-01-preview",
             "properties": "[parameters('dataMaskingRules')[copyIndex()]]",
             "copy": {
                 "name": "dataMaskingRuleCopy",

--- a/templates/sql-server.json
+++ b/templates/sql-server.json
@@ -115,7 +115,7 @@
                 {
                     "type": "administrators",
                     "name": "activeDirectory",
-                    "apiVersion": "2014-04-01-preview",
+                    "apiVersion": "2024-05-01-preview",
                     "location": "[resourceGroup().location]",
                     "properties": {
                         "administratorType": "ActiveDirectory",


### PR DESCRIPTION
Updates SQL API versions across ARM templates, as per MS recommendations before the version is retired on 31/10/2025.