### PR TITLE
Enable SAS Expiry Logging

### DIFF
--- a/ArmTemplates/storage-account-arm.json
+++ b/ArmTemplates/storage-account-arm.json
@@ -158,7 +158,7 @@
   },
   "resources": [
     {
-      "apiVersion": "2019-04-01",
+      "apiVersion": "2024-01-01",
       "name": "[parameters('storageAccountName')]",
       "type": "Microsoft.Storage/storageAccounts",
       "location": "[parameters('storageAccountLocation')]",
@@ -184,7 +184,11 @@
         "allowSharedKeyAccess": "[parameters('allowSharedKeyAccess')]",
         "supportsHttpsTrafficOnly": true,
         "minimumTlsVersion": "[parameters('minimumTlsVersion')]",
-        "networkAcls": "[if(or(greater(length(parameters('subnetResourceIdList')), 0),greater(length(parameters('allowedIpAddressesList')), 0)), variables('networkAclObject'), json('null'))]"
+        "networkAcls": "[if(or(greater(length(parameters('subnetResourceIdList')), 0),greater(length(parameters('allowedIpAddressesList')), 0)), variables('networkAclObject'), json('null'))]",
+        "sasPolicy": {
+          "expirationAction": "Log",
+          "sasExpirationPeriod": "0.01:00:00"
+        }
       },
       "resources": [
         {


### PR DESCRIPTION
Enables logging for when SAS tokens are created with an expiry date longer than 1 hour.