### PR TITLE
Disable Storage Account Cross Tenant Replication

### DIFF
--- a/ArmTemplates/storage-account-arm.json
+++ b/ArmTemplates/storage-account-arm.json
@@ -169,7 +169,7 @@
   },
   "resources": [
     {
-      "apiVersion": "2019-04-01",
+      "apiVersion": "2024-01-01",
       "name": "[parameters('storageAccountName')]",
       "type": "Microsoft.Storage/storageAccounts",
       "location": "[parameters('storageAccountLocation')]",
@@ -195,7 +195,8 @@
         "allowSharedKeyAccess": "[parameters('allowSharedKeyAccess')]",
         "supportsHttpsTrafficOnly": true,
         "minimumTlsVersion": "[parameters('minimumTlsVersion')]",
-        "networkAcls": "[if(or(greater(length(parameters('subnetResourceIdList')), 0),greater(length(parameters('allowedIpAddressesList')), 0)), variables('networkAclObject'), json('null'))]"
+        "networkAcls": "[if(or(greater(length(parameters('subnetResourceIdList')), 0),greater(length(parameters('allowedIpAddressesList')), 0)), variables('networkAclObject'), json('null'))]",
+        "allowCrossTenantReplication": false
       },
       "resources": [
         {


### PR DESCRIPTION
As per ITHC recommendations, cross tenant replication has been disabled for storage accounts (it is enabled by default for storage accounts created before Dec 15th 2023, disabled by default for ones created after this date). There are no object replication policies in place for T Levels storage accounts so this does not need to be enabled.