### PR TITLE
Update TLS Cypher Suites & Min TLS Version

### DIFF
--- a/ArmTemplates/app-service.json
+++ b/ArmTemplates/app-service.json
@@ -192,6 +192,18 @@
       "metadata": {
         "description": "Used for allowing SCM & FTP basic auth publishing"
       }
+    },
+    "minTlsCipherSuite": {
+      "type": "string",
+      "defaultValue": "TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA256"
+    },
+    "minTlsVersion": {
+      "type": "string",
+      "defaultValue": "1.2",
+      "allowedValues": [
+        "1.2",
+        "1.3"
+      ]
     }
   },
   "variables": {
@@ -199,7 +211,7 @@
     "appServicePlanId": "[resourceId(parameters('appServicePlanResourceGroup'), 'Microsoft.Web/serverfarms', parameters('appServicePlanName'))]",
     "useAppServiceSlotAppSettings": "[greater(length(parameters('appServiceSlotAppSettings')), 0)]",
     "useAppServiceSlotConnectionStrings": "[greater(length(parameters('appServiceSlotConnectionStrings')), 0)]",
-    "appServiceApiVersion": "2020-09-01"
+    "appServiceApiVersion": "2025-03-01"
   },
   "resources": [
     {
@@ -224,7 +236,9 @@
           "use32BitWorkerProcess": "[parameters('use32BitWorkerProcess')]",
           "http20Enabled": "[parameters('http20Enabled')]",
           "ftpsState": "[parameters('ftpsState')]",
-          "healthCheckPath": "[parameters('healthCheckPath')]"
+          "healthCheckPath": "[parameters('healthCheckPath')]",
+          "minTlsCipherSuite": "[parameters('minTlsCipherSuite')]",
+          "MinTlsVersion": "[parameters('minTlsVersion')]"
         },
         "httpsOnly": true
       },

--- a/ArmTemplates/sql-server.json
+++ b/ArmTemplates/sql-server.json
@@ -139,8 +139,8 @@
       "properties": {
         "administratorLogin": "[parameters('sqlServerAdminUserName')]",
         "administratorLoginPassword": "[parameters('sqlServerAdminPassword')]",
-        "primaryUserAssignedIdentityId": "[resourceId('Microsoft.ManagedIdentity/userAssignedIdentities', concat(parameters('sqlServerName'), '-umi'))]"
-
+        "primaryUserAssignedIdentityId": "[resourceId('Microsoft.ManagedIdentity/userAssignedIdentities', concat(parameters('sqlServerName'), '-umi'))]",
+        "minimalTlsVersion": "1.2"
       },
       "resources": [
         {


### PR DESCRIPTION
This update enforces stronger security standards by setting minimum cypher suites used by app services to TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA256 & updating the minimum TLS version used by SQL servers to 1.2