### PR TITLE
TLD-693: Add reusable Key Vault RBAC role assignment template

### DIFF
--- a/ArmTemplates/role-assignments/role-assignment-key-vault.json
+++ b/ArmTemplates/role-assignments/role-assignment-key-vault.json
@@ -17,9 +17,6 @@
     },
     "resourceName": {
       "type": "string"
-    },
-    "scope": {
-      "type": "string"
     }
   },
   "variables": {
@@ -33,11 +30,10 @@
     {
       "type": "Microsoft.KeyVault/vaults/providers/roleAssignments",
       "apiVersion": "2020-04-01-preview",
-      "name": "[concat(parameters('resourceName'), '/Microsoft.Authorization/', guid(uniqueString(parameters('principalId')), parameters('assignmentType'), 'key-vault'))]",
+      "name": "[concat(parameters('resourceName'), '/Microsoft.Authorization/', guid(parameters('resourceName'), parameters('principalId'), parameters('assignmentType')))]",
       "properties": {
         "roleDefinitionId": "[variables(parameters('assignmentType'))]",
-        "principalId": "[parameters('principalId')]",
-        "scope": "[parameters('scope')]"
+        "principalId": "[parameters('principalId')]"
       }
     }
   ]

--- a/ArmTemplates/role-assignments/role-assignment-key-vault.json
+++ b/ArmTemplates/role-assignments/role-assignment-key-vault.json
@@ -1,0 +1,44 @@
+{
+  "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+  "contentVersion": "1.0.0.0",
+  "parameters": {
+    "assignmentType": {
+      "type": "string",
+      "allowedValues": [
+        "Key Vault Administrator",
+        "Key Vault Reader",
+        "Key Vault Secrets Officer",
+        "Key Vault Secrets User",
+        "Key Vault Crypto Officer"
+      ]
+    },
+    "principalId": {
+      "type": "string"
+    },
+    "resourceName": {
+      "type": "string"
+    },
+    "scope": {
+      "type": "string"
+    }
+  },
+  "variables": {
+    "Key Vault Administrator": "[concat('/subscriptions/', subscription().subscriptionId, '/providers/Microsoft.Authorization/roleDefinitions/', '00482a5a-887f-4fb3-b363-3b7fe8e74483')]",
+    "Key Vault Reader": "[concat('/subscriptions/', subscription().subscriptionId, '/providers/Microsoft.Authorization/roleDefinitions/', '21090545-7ca7-4776-b22c-e363652d74d2')]",
+    "Key Vault Secrets Officer": "[concat('/subscriptions/', subscription().subscriptionId, '/providers/Microsoft.Authorization/roleDefinitions/', 'b86a8fe4-44ce-4948-aee5-eccb2c155cd7')]",
+    "Key Vault Secrets User": "[concat('/subscriptions/', subscription().subscriptionId, '/providers/Microsoft.Authorization/roleDefinitions/', '4633458b-17de-408a-b874-0445c86b69e6')]",
+    "Key Vault Crypto Officer": "[concat('/subscriptions/', subscription().subscriptionId, '/providers/Microsoft.Authorization/roleDefinitions/', '14b46e9e-c2b7-41b4-b07b-48a6ebf60603')]"
+  },
+  "resources": [
+    {
+      "type": "Microsoft.KeyVault/vaults/providers/roleAssignments",
+      "apiVersion": "2020-04-01-preview",
+      "name": "[concat(parameters('resourceName'), '/Microsoft.Authorization/', guid(uniqueString(parameters('principalId')), parameters('assignmentType'), 'key-vault'))]",
+      "properties": {
+        "roleDefinitionId": "[variables(parameters('assignmentType'))]",
+        "principalId": "[parameters('principalId')]",
+        "scope": "[parameters('scope')]"
+      }
+    }
+  ]
+}

--- a/ArmTemplates/role-assignments/role-assignment-user-assigned-identity.json
+++ b/ArmTemplates/role-assignments/role-assignment-user-assigned-identity.json
@@ -24,7 +24,7 @@
   "resources": [
     {
         "type": "Microsoft.ManagedIdentity/userAssignedIdentities/providers/roleAssignments",
-        "apiVersion": "2020-04-01-preview",
+        "apiVersion": "2020-04-01",
         "name": "[concat(parameters('resourceName'), '/Microsoft.Authorization/', guid(uniqueString(parameters('principalId')),'user-assigned-identity'))]",
         "properties": {
             "roleDefinitionId": "[variables(parameters('assignmentType'))]",


### PR DESCRIPTION
Adds a reusable ARM template for assigning Azure RBAC roles at the Key Vault scope.

Changes:

- Added Key Vault scoped role assignment template

Supports the following built-in roles:
Key Vault Administrator
Key Vault Reader
Key Vault Secrets Officer
Key Vault Secrets User
Key Vault Crypto Officer

- Uses deterministic GUID naming for idempotent deployments

Parameterized:
principalId
assignmentType
resourceName

This change supports the ongoing migration from Key Vault access policies toward Azure RBAC-based authorization.

The template is intended to be consumed by shared.json file for all three t-levels service repos (results and certification, find a provider api, and marketing and communications).